### PR TITLE
Ignore all metrics that are 1DPM

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,7 +49,8 @@ def get_metric_rates(url,username,api_key,metric_names):
             query_data = query_response.json().get( "data", {}).get("result", [])
             if query_data and len(query_data) > 0 and len(query_data[0].get('value', [])) > 1:
                 dpm = query_data[0]['value'][1]
-                if float(dpm) > 0:
+                # Only show metrics that are not 1dpm
+                if float(dpm) != 1:
                     print(metric_name, dpm)
                     f.write(f"{metric_name} {dpm}\n")
             else:


### PR DESCRIPTION
We don't tend to care about metrics that are 1dpm, so this change only echos out those that are above or below 1dpm.

Example output:

```
# python ./main.py 
gitlab_component_apdex:ratio_1h 0.8
gitlab_component_apdex:ratio_30m 0.4
gitlab_component_apdex:ratio_5m 0.8
gitlab_component_apdex:ratio_6h 0.4
gitlab_component_apdex:success:rate_1h 0.8
gitlab_component_apdex:success:rate_30m 0.4
gitlab_component_apdex:success:rate_5m 0.8
gitlab_component_apdex:success:rate_6h 0.4
gitlab_component_apdex:weight:score_1h 0.8
gitlab_component_apdex:weight:score_30m 0.4
gitlab_component_apdex:weight:score_5m 0.8
gitlab_component_apdex:weight:score_6h 0.4
```