### PR TITLE
fix: improve DPM accuracy for push-based OTel metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The script does the following:
     - Metrics ending with `_count`, `_bucket`, or `_sum` (histogram/summary components)
     - Metrics beginning with `grafana_` (Grafana internal metrics)
     - Metrics with aggregation rules defined in the cluster
-3.  **Calculates DPM rate** for each metric using a PromQL query: `count_over_time({metric_name}[5m])/5`.
+3.  **Calculates DPM rate** for each metric using a PromQL query: `count_over_time({metric_name}[Nm])/N` (where N is the configurable lookback window in minutes, default 10).
 4.  **Filters results** based on a DPM threshold (metrics with DPM > 1 by default).
 5.  **Outputs results** in various formats:
     - **One-time mode**: CSV, JSON, text, or Prometheus exposition format files
@@ -382,7 +382,7 @@ All log messages include timestamps and severity levels for better monitoring an
 ## Usage
 
 
-usage: dpm-finder.py [-h] [-f {csv,text,txt,json,prom}] [-m MIN_DPM] [-q] [-v] [-t THREADS] [-e] [-p PORT] [-u UPDATE_INTERVAL]
+usage: dpm-finder.py [-h] [-f {csv,text,txt,json,prom}] [-m MIN_DPM] [-q] [-v] [-t THREADS] [-e] [-p PORT] [-u UPDATE_INTERVAL] [--timeout TIMEOUT] [-l LOOKBACK] [--cost-per-1000-series COST]
 
 
         DPM Finder - A tool to calculate Data Points per Minute (DPM) for Prometheus metrics.
@@ -402,11 +402,17 @@ optional arguments:
   -v, --verbose         Enable debug logging for detailed output
   -t THREADS, --threads THREADS
                         Number of concurrent threads for processing metrics (minimum: 1, default: 10)
-
+  -l LOOKBACK, --lookback LOOKBACK
+                        Lookback window in minutes for DPM calculation (default: 10). Larger values
+                        improve accuracy for push-based/OTel metrics with irregular intervals.
   -e, --exporter        Run as a Prometheus exporter server instead of one-time execution
   -p PORT, --port PORT   Port to run the exporter server on (default: 9966)
   -u UPDATE_INTERVAL, --update-interval UPDATE_INTERVAL
                          How often to update metrics in exporter mode, in seconds (default: 1 day or 86400 seconds)
+  --timeout TIMEOUT     Request timeout in seconds for Prometheus API calls (default: 60)
+  --cost-per-1000-series COST
+                        Dollar cost per 1000 active series. If provided, output includes estimated_cost
+                        and is sorted by highest cost.
 
 ## Filtered Metrics
 

--- a/docs/superpowers/plans/2026-04-10-dpm-accuracy.md
+++ b/docs/superpowers/plans/2026-04-10-dpm-accuracy.md
@@ -1,0 +1,515 @@
+# DPM Accuracy Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix DPM underreporting by using max-across-series instead of result[0], increase the default lookback window from 5m to 10m, make it configurable, and add per-series detail to JSON/text output.
+
+**Architecture:** All changes are in `dpm-finder.py`. The `lookback` parameter is threaded through `main()` -> `get_metric_rates()` -> `process_metric_chunk()` (and the exporter path). The DPM result handling switches from picking `result[0]` to iterating all results, taking the max, and collecting per-series detail. Output formatters are updated to include the detail where appropriate.
+
+**Tech Stack:** Python 3, Prometheus HTTP API, argparse
+
+---
+
+### Task 1: Add `--lookback` CLI flag and thread it through the call chain
+
+**Files:**
+- Modify: `dpm-finder.py:750-755` (add argparse argument after `--timeout`)
+- Modify: `dpm-finder.py:784` (add validation)
+- Modify: `dpm-finder.py:800` (add to startup log)
+- Modify: `dpm-finder.py:258` (`get_metric_rates` signature)
+- Modify: `dpm-finder.py:334` (pass to `process_metric_chunk`)
+- Modify: `dpm-finder.py:176` (`process_metric_chunk` signature)
+- Modify: `dpm-finder.py:527` (`run_metrics_updater` signature)
+- Modify: `dpm-finder.py:578` (`run_exporter` signature)
+- Modify: `dpm-finder.py:814-843` (pass `lookback` in all call sites in `main()`)
+
+- [ ] **Step 1: Add the argparse argument**
+
+In `main()`, after the `--timeout` argument block (line 749), add:
+
+```python
+    parser.add_argument(
+        '-l', '--lookback',
+        type=int,
+        default=10,
+        help='Lookback window in minutes for DPM calculation (default: 10)'
+    )
+```
+
+- [ ] **Step 2: Add validation for lookback**
+
+After the timeout validation block (line 784), add:
+
+```python
+    if args.lookback < 1:
+        logger.error(f"Invalid lookback {args.lookback}, must be at least 1 minute")
+        sys.exit(1)
+```
+
+- [ ] **Step 3: Add lookback to startup log**
+
+After the timeout log line (line 800), add:
+
+```python
+        logger.info(f"- Lookback window: {args.lookback}m")
+```
+
+- [ ] **Step 4: Thread `lookback` through `process_metric_chunk`**
+
+Change the signature at line 176 from:
+
+```python
+def process_metric_chunk(chunk, metric_value_url, username, api_key, results_queue, quiet=False, timeout=60):
+```
+
+to:
+
+```python
+def process_metric_chunk(chunk, metric_value_url, username, api_key, results_queue, quiet=False, timeout=60, lookback=10):
+```
+
+- [ ] **Step 5: Thread `lookback` through `get_metric_rates`**
+
+Change the signature at line 258 from:
+
+```python
+def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_aggregations, output_format='csv', min_dpm=1, quiet=False, thread_count=10, exporter_mode=False, timeout=60, cost_per_1000_series=None):
+```
+
+to:
+
+```python
+def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_aggregations, output_format='csv', min_dpm=1, quiet=False, thread_count=10, exporter_mode=False, timeout=60, cost_per_1000_series=None, lookback=10):
+```
+
+- [ ] **Step 6: Pass `lookback` from `get_metric_rates` to `process_metric_chunk`**
+
+Change the `executor.submit` call at line 333-335 from:
+
+```python
+        futures = [
+            executor.submit(process_metric_chunk, chunk, metric_value_url, username, api_key, results_queue, quiet, timeout)
+            for chunk in metric_chunks
+        ]
+```
+
+to:
+
+```python
+        futures = [
+            executor.submit(process_metric_chunk, chunk, metric_value_url, username, api_key, results_queue, quiet, timeout, lookback)
+            for chunk in metric_chunks
+        ]
+```
+
+- [ ] **Step 7: Thread `lookback` through `run_metrics_updater`**
+
+Change the signature at line 527 from:
+
+```python
+def run_metrics_updater(metric_value_url, metric_name_url, metric_aggregation_url, username, api_key, 
+                       min_dpm, thread_count, update_interval, quiet, timeout=60):
+```
+
+to:
+
+```python
+def run_metrics_updater(metric_value_url, metric_name_url, metric_aggregation_url, username, api_key, 
+                       min_dpm, thread_count, update_interval, quiet, timeout=60, lookback=10):
+```
+
+And pass it to `get_metric_rates` inside `collect_and_update_metrics()` (line 544). Change:
+
+```python
+                success = get_metric_rates(
+                    metric_value_url,
+                    username,
+                    api_key,
+                    metric_names,
+                    metric_aggregations,
+                    min_dpm=min_dpm,
+                    quiet=True,  # Always quiet for background updates
+                    thread_count=thread_count,
+                    exporter_mode=True,
+                    timeout=timeout
+                )
+```
+
+to:
+
+```python
+                success = get_metric_rates(
+                    metric_value_url,
+                    username,
+                    api_key,
+                    metric_names,
+                    metric_aggregations,
+                    min_dpm=min_dpm,
+                    quiet=True,  # Always quiet for background updates
+                    thread_count=thread_count,
+                    exporter_mode=True,
+                    timeout=timeout,
+                    lookback=lookback
+                )
+```
+
+- [ ] **Step 8: Thread `lookback` through `run_exporter`**
+
+Change the signature at line 578 from:
+
+```python
+def run_exporter(port, metric_value_url, metric_name_url, metric_aggregation_url, username, api_key,
+                min_dpm, thread_count, update_interval, quiet, timeout=60):
+```
+
+to:
+
+```python
+def run_exporter(port, metric_value_url, metric_name_url, metric_aggregation_url, username, api_key,
+                min_dpm, thread_count, update_interval, quiet, timeout=60, lookback=10):
+```
+
+Pass it to `get_metric_rates` inside `initial_metrics_collection()` (line 619). Change:
+
+```python
+            success = get_metric_rates(
+                metric_value_url,
+                username,
+                api_key,
+                metric_names,
+                metric_aggregations,
+                min_dpm=min_dpm,
+                quiet=quiet,
+                thread_count=thread_count,
+                exporter_mode=True,
+                timeout=timeout
+            )
+```
+
+to:
+
+```python
+            success = get_metric_rates(
+                metric_value_url,
+                username,
+                api_key,
+                metric_names,
+                metric_aggregations,
+                min_dpm=min_dpm,
+                quiet=quiet,
+                thread_count=thread_count,
+                exporter_mode=True,
+                timeout=timeout,
+                lookback=lookback
+            )
+```
+
+Pass it to `run_metrics_updater` in the thread args (line 653). Change:
+
+```python
+        args=(metric_value_url, metric_name_url, metric_aggregation_url, username, api_key,
+              min_dpm, thread_count, update_interval, quiet, timeout),
+```
+
+to:
+
+```python
+        args=(metric_value_url, metric_name_url, metric_aggregation_url, username, api_key,
+              min_dpm, thread_count, update_interval, quiet, timeout, lookback),
+```
+
+- [ ] **Step 9: Pass `lookback` from `main()` to all call sites**
+
+In the exporter call (line 816), add `lookback=args.lookback`:
+
+```python
+        run_exporter(
+            port=args.port,
+            metric_value_url=metric_value_url,
+            metric_name_url=metric_name_url,
+            metric_aggregation_url=metric_aggregation_url,
+            username=username,
+            api_key=api_key,
+            min_dpm=args.min_dpm,
+            thread_count=args.threads,
+            update_interval=args.update_interval,
+            quiet=args.quiet,
+            timeout=args.timeout,
+            lookback=args.lookback
+        )
+```
+
+In the one-time execution call (line 831), add `lookback=args.lookback`:
+
+```python
+        get_metric_rates(
+            metric_value_url,
+            username,
+            api_key,
+            metric_names,
+            metric_aggregations,
+            output_format=args.format,
+            min_dpm=args.min_dpm,
+            quiet=args.quiet,
+            thread_count=args.threads,
+            timeout=args.timeout,
+            cost_per_1000_series=args.cost_per_1000_series,
+            lookback=args.lookback
+        )
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add dpm-finder.py
+git commit -m "feat: add --lookback flag and thread through call chain
+
+Default lookback window increased from 5m to 10m to better capture
+bursty push-based metrics. Configurable via -l/--lookback (minutes)."
+```
+
+---
+
+### Task 2: Update DPM query to use configurable lookback and fix result handling
+
+**Files:**
+- Modify: `dpm-finder.py:188-217` (DPM query and result extraction in `process_metric_chunk`)
+- Modify: `dpm-finder.py:247-252` (result storage)
+
+- [ ] **Step 1: Update the PromQL query to use `lookback`**
+
+In `process_metric_chunk`, change lines 188-189 from:
+
+```python
+        # DPM over last 5 minutes, per minute
+        query_dpm = 'count_over_time(%s{__ignore_usage__=""}[5m])/5' % (metric)
+```
+
+to:
+
+```python
+        # DPM over lookback window, per minute
+        query_dpm = 'count_over_time(%s{__ignore_usage__=""}[%dm])/%d' % (metric, lookback, lookback)
+```
+
+- [ ] **Step 2: Replace `result[0]` with max-across-series and per-series collection**
+
+Replace lines 208-217 (the result extraction block) with:
+
+```python
+        try:
+            query_data_dpm = response_dpm.json().get("data", {}).get("result", [])
+            dpm_value = None
+            series_detail = []
+            for series in query_data_dpm:
+                if len(series.get('value', [])) > 1:
+                    try:
+                        s_dpm = float(series['value'][1])
+                    except (ValueError, TypeError):
+                        continue
+                    labels = {k: v for k, v in series.get('metric', {}).items()
+                              if k != '__name__' and k != '__ignore_usage__'}
+                    series_detail.append({'labels': labels, 'dpm': s_dpm})
+                    if dpm_value is None or s_dpm > dpm_value:
+                        dpm_value = s_dpm
+        except Exception as e:
+            if not quiet:
+                logger.error(f"Error parsing response for metric {metric}: {str(e)}")
+            dpm_value = None
+            series_detail = []
+```
+
+- [ ] **Step 3: Update result storage to include `series_detail`**
+
+Replace lines 247-252 (the result storage block) with:
+
+```python
+        # Only store metrics we could compute a DPM for
+        if dpm_value is not None:
+            chunk_results[metric] = {
+                'dpm': dpm_value,
+                'series_count': series_count_value if series_count_value is not None else "0",
+                'series_detail': series_detail
+            }
+```
+
+- [ ] **Step 4: Verify against live Prometheus**
+
+Run a quick manual test against the live instance:
+
+```bash
+python3 -c "
+import os, requests
+from dotenv import load_dotenv
+from requests.auth import HTTPBasicAuth
+
+load_dotenv()
+endpoint = os.getenv('PROMETHEUS_ENDPOINT')
+username = os.getenv('PROMETHEUS_USERNAME')
+api_key = os.getenv('PROMETHEUS_API_KEY')
+url = f'{endpoint}/api/prom/api/v1/query'
+auth = HTTPBasicAuth(username, api_key)
+
+metric = 'openwebui_users_active'
+lookback = 10
+
+query = 'count_over_time(%s{__ignore_usage__=\"\"}[%dm])/%d' % (metric, lookback, lookback)
+response = requests.get(url, auth=auth, params={'query': query}, timeout=60)
+result = response.json().get('data', {}).get('result', [])
+
+dpm_value = None
+series_detail = []
+for series in result:
+    if len(series.get('value', [])) > 1:
+        s_dpm = float(series['value'][1])
+        labels = {k: v for k, v in series.get('metric', {}).items()
+                  if k != '__name__' and k != '__ignore_usage__'}
+        series_detail.append({'labels': labels, 'dpm': s_dpm})
+        if dpm_value is None or s_dpm > dpm_value:
+            dpm_value = s_dpm
+
+print(f'Headline DPM (max): {dpm_value}')
+print(f'Series count: {len(series_detail)}')
+for s in series_detail:
+    env = s['labels'].get('environment', '?')
+    print(f'  {env}: {s[\"dpm\"]}')
+"
+```
+
+Expected: headline DPM should be the tst or prd value (~3-5), not sbx (1). All 4 environments listed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dpm-finder.py
+git commit -m "fix: use max-across-series for DPM instead of result[0]
+
+Previously took the first arbitrary series from the query result,
+which could severely underreport DPM. Now iterates all series,
+takes the max as headline DPM, and collects per-series detail."
+```
+
+---
+
+### Task 3: Thread `series_detail` through enrichment and update output formatters
+
+**Files:**
+- Modify: `dpm-finder.py:365-387` (enrichment loop)
+- Modify: `dpm-finder.py:437-452` (JSON output)
+- Modify: `dpm-finder.py:497-513` (text output)
+
+CSV, prom, and exporter output are unchanged (headline DPM only, same columns).
+
+- [ ] **Step 1: Pass `series_detail` through the enrichment loop**
+
+In the enrichment loop (lines 365-387), change the `enriched.append` block from:
+
+```python
+        enriched.append({
+            'metric_name': metric_name,
+            'dpm': dpm_val,
+            'series_count': int(series_val),
+            'estimated_cost': estimated_cost
+        })
+```
+
+to:
+
+```python
+        enriched.append({
+            'metric_name': metric_name,
+            'dpm': dpm_val,
+            'series_count': int(series_val),
+            'estimated_cost': estimated_cost,
+            'series_detail': payload.get('series_detail', [])
+        })
+```
+
+- [ ] **Step 2: Update JSON output to include `series_detail`**
+
+No code change needed. The `enriched` list is already serialized directly into the JSON output at line 440:
+
+```python
+        output_data = {
+            "metrics": enriched,
+            ...
+        }
+```
+
+Since `series_detail` is now in each enriched entry, it will be included automatically. Verify that the `series_detail` list of dicts (with `labels` dict and `dpm` float) is JSON-serializable — it is, since it contains only strings and floats.
+
+- [ ] **Step 3: Update text output to show per-series breakdown**
+
+In the text output block (lines 497-513), change the loop body from:
+
+```python
+            for item in enriched:
+                metric_name = item['metric_name']
+                dpm = item['dpm']
+                series_count = item['series_count']
+                if cost_per_1000_series is not None and item['estimated_cost'] is not None:
+                    output_line = f"{metric_name}: dpm={dpm}, series={series_count}, estimated_cost={item['estimated_cost']}\n"
+                else:
+                    output_line = f"{metric_name}: dpm={dpm}, series={series_count}\n"
+                if not quiet:
+                    print(output_line, end='')
+                f.write(output_line)
+```
+
+to:
+
+```python
+            for item in enriched:
+                metric_name = item['metric_name']
+                dpm = item['dpm']
+                series_count = item['series_count']
+                if cost_per_1000_series is not None and item['estimated_cost'] is not None:
+                    output_line = f"{metric_name}: dpm={dpm}, series={series_count}, estimated_cost={item['estimated_cost']}\n"
+                else:
+                    output_line = f"{metric_name}: dpm={dpm}, series={series_count}\n"
+                if not quiet:
+                    print(output_line, end='')
+                f.write(output_line)
+                # Per-series breakdown
+                for s in item.get('series_detail', []):
+                    label_str = ', '.join(f'{k}={v}' for k, v in s['labels'].items())
+                    detail_line = f"  {label_str}: dpm={s['dpm']}\n"
+                    if not quiet:
+                        print(detail_line, end='')
+                    f.write(detail_line)
+```
+
+- [ ] **Step 4: End-to-end test against live Prometheus**
+
+Run the script in JSON mode with a high `min_dpm` so it finishes quickly, and verify `openwebui_users_active` output:
+
+```bash
+python3 dpm-finder.py --format json --min-dpm 0.5 --lookback 10 --quiet 2>/dev/null && python3 -c "
+import json
+with open('metric_rates.json') as f:
+    data = json.load(f)
+for m in data['metrics']:
+    if m['metric_name'] == 'openwebui_users_active':
+        print(f\"DPM: {m['dpm']}\")
+        print(f\"Series count: {m['series_count']}\")
+        print(f\"Series detail entries: {len(m.get('series_detail', []))}\")
+        for s in m.get('series_detail', []):
+            print(f\"  {s['labels'].get('environment', '?')}: {s['dpm']}\")
+        break
+else:
+    print('metric not found in output')
+"
+```
+
+Expected: DPM is the max across environments (not 1.0 from sbx), series_detail has 4 entries.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dpm-finder.py
+git commit -m "feat: add per-series DPM breakdown to JSON and text output
+
+JSON output now includes series_detail array with labels and DPM per
+series. Text output shows indented per-series lines below each metric.
+CSV and prom formats unchanged."
+```

--- a/docs/superpowers/results/2026-04-10-dpm-accuracy-results.md
+++ b/docs/superpowers/results/2026-04-10-dpm-accuracy-results.md
@@ -1,0 +1,70 @@
+# DPM Accuracy Improvements - Results
+
+## Test Metric: `openwebui_users_active`
+
+Tested against live Prometheus at `prometheus-prod-65-prod-eu-west-2.grafana.net` on 2026-04-10. This metric has 4 environments (sbx, dev, tst, prd) pushed via OTel gateway with irregular intervals.
+
+## Before (old behavior)
+
+Query: `count_over_time(openwebui_users_active{__ignore_usage__=""}[5m])/5`
+
+The script took `result[0]` from the Prometheus response, which was an arbitrary series:
+
+```
+Script picks result[0] -> dpm_value = 1
+Script picks environment: sbx
+```
+
+| Environment | Actual DPM | Reported by script |
+|-------------|------------|-------------------|
+| sbx         | 1.0        | 1.0 (picked as result[0]) |
+| dev         | 1.0        | ignored |
+| tst         | 3.2-5.0    | ignored |
+| prd         | 2.6-3.0    | ignored |
+
+Total DPM across all series: ~9.6. Script reported: 1.0.
+
+### Problems identified
+
+1. **`result[0]` bug**: Only the first series in the response was used. For `openwebui_users_active`, this was `sbx` (the lowest DPM environment), causing severe underreporting.
+
+2. **5-minute lookback too narrow**: For bursty push-based metrics via OTel gateway, a 5-minute window risks missing samples entirely depending on query timing. The `tst` environment sends ~3 samples per minute in irregular bursts (~5s, ~20s, ~34s gaps).
+
+## After (new behavior)
+
+Query: `count_over_time(openwebui_users_active{__ignore_usage__=""}[10m])/10`
+
+The script now iterates all series, takes the max as headline DPM, and collects per-series detail:
+
+```
+Headline DPM (max): 3.0
+Series: 8
+  tst: 3.0
+  prd: 3.0
+  sbx: 1.0
+  dev: 1.0
+  dev: 0.4
+  tst: 0.3
+  tst: 0.2
+  tst: 0.1
+```
+
+| Change | Before | After |
+|--------|--------|-------|
+| Headline DPM | 1.0 (arbitrary result[0]) | 3.0 (max across series) |
+| Lookback window | 5m (hardcoded) | 10m (default, configurable via `--lookback`) |
+| Per-series detail | Not available | Available in JSON and text output |
+| Series visibility | 1 of 8 | 8 of 8 |
+
+## Changes made
+
+1. **`--lookback` / `-l` flag** (default: 10 minutes, minimum: 1) - configurable lookback window for DPM calculation
+2. **Max-across-series** - headline DPM is now the maximum of any single series, not an arbitrary first result
+3. **Per-series breakdown** - JSON output includes `series_detail` array with labels and DPM per series; text output shows indented per-series lines below each metric
+4. **CSV and prom formats unchanged** - backward compatible
+
+## Commits
+
+- `a1aa79d` feat: add --lookback flag and thread through call chain
+- `edfee5c` fix: use max-across-series for DPM instead of result[0]
+- `04273ff` feat: add per-series DPM breakdown to JSON and text output

--- a/docs/superpowers/specs/2026-04-10-dpm-accuracy-design.md
+++ b/docs/superpowers/specs/2026-04-10-dpm-accuracy-design.md
@@ -1,0 +1,64 @@
+# DPM Accuracy Improvements
+
+## Problem
+
+The script has two bugs that cause it to miss or underreport metrics, especially push-based OTel metrics with irregular intervals:
+
+1. **`result[0]` bug**: The DPM query (`count_over_time(metric[5m])/5`) returns one result per series (unique label combination), but the script only takes `result[0]`. This picks an arbitrary series whose DPM may be much lower than the busiest series, or even 0 if that series has no samples in the window. Metrics can be filtered out entirely by `min_dpm`.
+
+2. **5-minute lookback too narrow**: For bursty push metrics (e.g., OTel gateway), a 5-minute window may catch zero samples depending on when the query runs, causing the metric to be missed.
+
+## Changes
+
+### 1. Configurable lookback window
+
+- New CLI flag: `--lookback` / `-l` (integer, minutes, default: 10)
+- Default increases from 5 to 10 minutes
+- Minimum: 1 minute
+- Flows into PromQL as both the range vector and divisor:
+  ```promql
+  count_over_time(metric{__ignore_usage__=""}[10m])/10
+  ```
+- Passed through `get_metric_rates` -> `process_metric_chunk`
+
+### 2. Fix result handling: use max across series
+
+The DPM query returns a vector with one entry per series. Instead of taking `result[0]`, iterate all results and:
+
+- **Headline DPM** = max DPM across all series
+- **Collect per-series detail**: each series' labels and individual DPM value
+
+The series count query (`count(metric{__ignore_usage__=""})`) is unchanged.
+
+### 3. Per-series breakdown in output
+
+Per-series data is collected during `process_metric_chunk` (no extra queries needed). Each metric's result includes a `series_detail` list.
+
+Data structure per metric:
+```python
+{
+    'dpm': 5.0,                   # max across series
+    'series_count': '4',
+    'series_detail': [
+        {'labels': {'environment': 'tst', ...}, 'dpm': 5.0},
+        {'labels': {'environment': 'prd', ...}, 'dpm': 2.6},
+        ...
+    ]
+}
+```
+
+Output format behavior:
+
+| Format | Behavior |
+|--------|----------|
+| JSON | `series_detail` array nested inside each metric entry with full labels + DPM |
+| CSV | One row per metric (headline = max DPM), columns unchanged |
+| Text | Headline row unchanged, per-series listed indented below each metric |
+| Prom | No change, one gauge per metric name using headline max DPM |
+| Exporter | No change, `update_prometheus_metrics` uses headline max DPM |
+
+## Scope
+
+- `dpm-finder.py`: query changes, result handling, CLI flag, output formatting
+- No new files or dependencies
+- Backward-compatible CSV output (same columns, same shape)

--- a/dpm-finder.py
+++ b/dpm-finder.py
@@ -185,8 +185,8 @@ def process_metric_chunk(chunk, metric_value_url, username, api_key, results_que
         if not quiet:
             logger.debug(f"Processing metric: {metric}")
         
-        # DPM over last 5 minutes, per minute
-        query_dpm = 'count_over_time(%s{__ignore_usage__=""}[5m])/5' % (metric)
+        # DPM over lookback window, per minute
+        query_dpm = 'count_over_time(%s{__ignore_usage__=""}[%dm])/%d' % (metric, lookback, lookback)
         response_dpm = make_request_with_retry(
             metric_value_url,
             auth=HTTPBasicAuth(username, api_key),
@@ -207,14 +207,24 @@ def process_metric_chunk(chunk, metric_value_url, username, api_key, results_que
             
         try:
             query_data_dpm = response_dpm.json().get("data", {}).get("result", [])
-            if query_data_dpm and len(query_data_dpm) > 0 and len(query_data_dpm[0].get('value', [])) > 1:
-                dpm_value = query_data_dpm[0]['value'][1]
-            else:
-                dpm_value = None
+            dpm_value = None
+            series_detail = []
+            for series in query_data_dpm:
+                if len(series.get('value', [])) > 1:
+                    try:
+                        s_dpm = float(series['value'][1])
+                    except (ValueError, TypeError):
+                        continue
+                    labels = {k: v for k, v in series.get('metric', {}).items()
+                              if k != '__name__' and k != '__ignore_usage__'}
+                    series_detail.append({'labels': labels, 'dpm': s_dpm})
+                    if dpm_value is None or s_dpm > dpm_value:
+                        dpm_value = s_dpm
         except Exception as e:
             if not quiet:
                 logger.error(f"Error parsing response for metric {metric}: {str(e)}")
             dpm_value = None
+            series_detail = []
         
         # Series cardinality (active series count at evaluation time)
         # Keep the same selector pattern for consistency with DPM query
@@ -248,7 +258,8 @@ def process_metric_chunk(chunk, metric_value_url, username, api_key, results_que
         if dpm_value is not None:
             chunk_results[metric] = {
                 'dpm': dpm_value,
-                'series_count': series_count_value if series_count_value is not None else "0"
+                'series_count': series_count_value if series_count_value is not None else "0",
+                'series_detail': series_detail
             }
         
         chunk_times.append(time.time() - metric_start_time)

--- a/dpm-finder.py
+++ b/dpm-finder.py
@@ -173,7 +173,7 @@ def get_metric_json(url, username, api_key, quiet=False, timeout=60):
             logger.error(f"Error parsing metric names response: {str(e)}")
         return None
 
-def process_metric_chunk(chunk, metric_value_url, username, api_key, results_queue, quiet=False, timeout=60, lookback=10):
+def process_metric_chunk(chunk, metric_value_url, username, api_key, results_queue, quiet=False, timeout=60, lookback=10, collect_series_detail=False):
     """
     Process a chunk of metrics and put results in the queue
     """
@@ -215,9 +215,10 @@ def process_metric_chunk(chunk, metric_value_url, username, api_key, results_que
                         s_dpm = float(series['value'][1])
                     except (ValueError, TypeError):
                         continue
-                    labels = {k: v for k, v in series.get('metric', {}).items()
-                              if k != '__name__' and k != '__ignore_usage__'}
-                    series_detail.append({'labels': labels, 'dpm': s_dpm})
+                    if collect_series_detail:
+                        labels = {k: v for k, v in series.get('metric', {}).items()
+                                  if k != '__name__' and k != '__ignore_usage__'}
+                        series_detail.append({'labels': labels, 'dpm': s_dpm})
                     if dpm_value is None or s_dpm > dpm_value:
                         dpm_value = s_dpm
         except Exception as e:
@@ -338,11 +339,14 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
     if not quiet:
         logger.info(f"Processing {total_metrics} metrics in {len(metric_chunks)} chunks using {thread_count} threads")
     
+    # Only collect per-series detail for formats that use it
+    collect_series_detail = not exporter_mode and output_format in ('json', 'text', 'txt')
+
     # Create thread pool with the specified number of threads
     with ThreadPoolExecutor(max_workers=thread_count) as executor:
         # Submit tasks to the thread pool
         futures = [
-            executor.submit(process_metric_chunk, chunk, metric_value_url, username, api_key, results_queue, quiet, timeout, lookback)
+            executor.submit(process_metric_chunk, chunk, metric_value_url, username, api_key, results_queue, quiet, timeout, lookback, collect_series_detail)
             for chunk in metric_chunks
         ]
         
@@ -395,7 +399,7 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
             'dpm': dpm_val,
             'series_count': int(series_val),
             'estimated_cost': estimated_cost,
-            'series_detail': payload.get('series_detail', [])
+            'series_detail': sorted(payload.get('series_detail', []), key=lambda x: x['dpm'], reverse=True)
         })
     
     # Filter metrics above DPM threshold
@@ -523,9 +527,9 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
                 if not quiet:
                     print(output_line, end='')
                 f.write(output_line)
-                # Per-series breakdown
+                # Per-series breakdown (pre-sorted by DPM descending)
                 for s in item.get('series_detail', []):
-                    label_str = ', '.join(f'{k}={v}' for k, v in s['labels'].items())
+                    label_str = ', '.join(f'{k}={v}' for k, v in s['labels'].items()) or '(no labels)'
                     detail_line = f"  {label_str}: dpm={s['dpm']}\n"
                     if not quiet:
                         print(detail_line, end='')

--- a/dpm-finder.py
+++ b/dpm-finder.py
@@ -394,7 +394,8 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
             'metric_name': metric_name,
             'dpm': dpm_val,
             'series_count': int(series_val),
-            'estimated_cost': estimated_cost
+            'estimated_cost': estimated_cost,
+            'series_detail': payload.get('series_detail', [])
         })
     
     # Filter metrics above DPM threshold
@@ -522,7 +523,14 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
                 if not quiet:
                     print(output_line, end='')
                 f.write(output_line)
-            
+                # Per-series breakdown
+                for s in item.get('series_detail', []):
+                    label_str = ', '.join(f'{k}={v}' for k, v in s['labels'].items())
+                    detail_line = f"  {label_str}: dpm={s['dpm']}\n"
+                    if not quiet:
+                        print(detail_line, end='')
+                    f.write(detail_line)
+
             # Add timing information to the text output
             f.write("\nPerformance Metrics:\n")
             f.write(f"Total runtime: {total_time:.2f} seconds\n")

--- a/dpm-finder.py
+++ b/dpm-finder.py
@@ -173,7 +173,7 @@ def get_metric_json(url, username, api_key, quiet=False, timeout=60):
             logger.error(f"Error parsing metric names response: {str(e)}")
         return None
 
-def process_metric_chunk(chunk, metric_value_url, username, api_key, results_queue, quiet=False, timeout=60):
+def process_metric_chunk(chunk, metric_value_url, username, api_key, results_queue, quiet=False, timeout=60, lookback=10):
     """
     Process a chunk of metrics and put results in the queue
     """
@@ -255,7 +255,7 @@ def process_metric_chunk(chunk, metric_value_url, username, api_key, results_que
     
     results_queue.put((chunk_results, chunk_times))
 
-def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_aggregations, output_format='csv', min_dpm=1, quiet=False, thread_count=10, exporter_mode=False, timeout=60, cost_per_1000_series=None):
+def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_aggregations, output_format='csv', min_dpm=1, quiet=False, thread_count=10, exporter_mode=False, timeout=60, cost_per_1000_series=None, lookback=10):
     """ 
     Calculate the metric rates
     Args:
@@ -331,7 +331,7 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
     with ThreadPoolExecutor(max_workers=thread_count) as executor:
         # Submit tasks to the thread pool
         futures = [
-            executor.submit(process_metric_chunk, chunk, metric_value_url, username, api_key, results_queue, quiet, timeout)
+            executor.submit(process_metric_chunk, chunk, metric_value_url, username, api_key, results_queue, quiet, timeout, lookback)
             for chunk in metric_chunks
         ]
         
@@ -524,8 +524,8 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
 
     return True
 
-def run_metrics_updater(metric_value_url, metric_name_url, metric_aggregation_url, username, api_key, 
-                       min_dpm, thread_count, update_interval, quiet, timeout=60):
+def run_metrics_updater(metric_value_url, metric_name_url, metric_aggregation_url, username, api_key,
+                       min_dpm, thread_count, update_interval, quiet, timeout=60, lookback=10):
     """
     Run periodic metrics updates for exporter mode
     """
@@ -551,7 +551,8 @@ def run_metrics_updater(metric_value_url, metric_name_url, metric_aggregation_ur
                     quiet=True,  # Always quiet for background updates
                     thread_count=thread_count,
                     exporter_mode=True,
-                    timeout=timeout
+                    timeout=timeout,
+                    lookback=lookback
                 )
                 if success:
                     logger.debug("Metrics updated successfully")
@@ -576,7 +577,7 @@ def run_metrics_updater(metric_value_url, metric_name_url, metric_aggregation_ur
     logger.info("Metrics updater stopped")
 
 def run_exporter(port, metric_value_url, metric_name_url, metric_aggregation_url, username, api_key,
-                min_dpm, thread_count, update_interval, quiet, timeout=60):
+                min_dpm, thread_count, update_interval, quiet, timeout=60, lookback=10):
     """
     Run the Prometheus exporter server
     """
@@ -626,7 +627,8 @@ def run_exporter(port, metric_value_url, metric_name_url, metric_aggregation_url
                 quiet=quiet,
                 thread_count=thread_count,
                 exporter_mode=True,
-                timeout=timeout
+                timeout=timeout,
+                lookback=lookback
             )
             if success:
                 logger.info("Initial metrics collection completed")
@@ -651,7 +653,7 @@ def run_exporter(port, metric_value_url, metric_name_url, metric_aggregation_url
     updater_thread = threading.Thread(
         target=run_metrics_updater,
         args=(metric_value_url, metric_name_url, metric_aggregation_url, username, api_key,
-              min_dpm, thread_count, update_interval, quiet, timeout),
+              min_dpm, thread_count, update_interval, quiet, timeout, lookback),
         daemon=True
     )
     updater_thread.start()
@@ -748,6 +750,12 @@ def main():
         help='Request timeout in seconds for Prometheus API calls (default: 60)'
     )
     parser.add_argument(
+        '-l', '--lookback',
+        type=int,
+        default=10,
+        help='Lookback window in minutes for DPM calculation (default: 10)'
+    )
+    parser.add_argument(
         '--cost-per-1000-series',
         type=float,
         default=None,
@@ -783,6 +791,10 @@ def main():
         logger.error(f"Invalid timeout {args.timeout}, must be at least 1 second")
         sys.exit(1)
 
+    if args.lookback < 1:
+        logger.error(f"Invalid lookback {args.lookback}, must be at least 1 minute")
+        sys.exit(1)
+
     if not args.quiet:
         if args.exporter:
             logger.info("Running in exporter mode:")
@@ -798,6 +810,7 @@ def main():
         logger.info(f"- Verbose mode: {args.verbose}")
         logger.info(f"- Thread count: {args.threads}")
         logger.info(f"- Request timeout: {args.timeout}s")
+        logger.info(f"- Lookback window: {args.lookback}m")
 
     load_dotenv()
     prometheus_endpoint=os.getenv("PROMETHEUS_ENDPOINT")
@@ -824,7 +837,8 @@ def main():
             thread_count=args.threads,
             update_interval=args.update_interval,
             quiet=args.quiet,
-            timeout=args.timeout
+            timeout=args.timeout,
+            lookback=args.lookback
         )
     else:
         # Run one-time execution
@@ -839,7 +853,8 @@ def main():
             quiet=args.quiet,
             thread_count=args.threads,
             timeout=args.timeout,
-            cost_per_1000_series=args.cost_per_1000_series
+            cost_per_1000_series=args.cost_per_1000_series,
+            lookback=args.lookback
         )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The DPM calculation had two bugs that caused it to **miss or severely underreport** metrics, particularly those pushed via OpenTelemetry gateways with irregular/bursty intervals:

### 1. `result[0]` bug — arbitrary series selection

The query `count_over_time(metric[5m])/5` returns one result **per series** (unique label combination), but the script only took `result[0]` — whichever series Prometheus happened to return first. For multi-series metrics, this meant:

- The reported DPM could be from the **lowest-traffic** series (e.g., a sandbox environment)
- If that arbitrary series had 0 samples in the window, the metric was **dropped entirely**

### 2. Hardcoded 5-minute lookback too narrow for push metrics

Scrape-based Prometheus metrics arrive at predictable intervals (~15-60s), so a 5-minute window reliably captures samples. But push-based OTel metrics arrive in irregular bursts — a 5-minute snapshot evaluated at the wrong moment can miss an entire burst cycle, reporting 0 DPM for a metric that actually has significant throughput.

## Live example: `openwebui_users_active`

This metric is pushed via an OTel gateway across 4 environments. The `tst` environment sends ~3 samples/minute in irregular bursts (~5s, ~20s, ~34s gaps).

**Before (old behavior):**
```
Script picks result[0] -> dpm_value = 1.0
Script picks environment: sbx

Total DPM across all series: 9.6
```
The script reported **1.0 DPM** (from the least active environment), missing 90% of the actual ingestion.

**After (new behavior):**
```
Headline DPM (max): 3.0
Series: 8
  tst: 3.0
  prd: 3.0
  sbx: 1.0
  dev: 1.0
  dev: 0.4
  tst: 0.3
  tst: 0.2
  tst: 0.1
```
Headline DPM correctly reflects the busiest series, and all series are visible.

## Changes

1. **Configurable lookback window** (`-l`/`--lookback`, default 10m, was hardcoded 5m) — wider default window captures bursty push metrics more reliably; tunable per environment
2. **Max-across-series DPM** — iterates all series returned by the query, uses the maximum as the headline DPM value (was: arbitrary `result[0]`)
3. **Per-series breakdown** — collects labels + DPM for each individual series:
   - **JSON**: `series_detail` array nested in each metric entry
   - **Text**: indented per-series lines below each metric
   - **CSV/Prom/Exporter**: unchanged (backward compatible)

## Test plan

- [x] Verified `--help` shows new `-l`/`--lookback` flag with correct default
- [x] Verified against live Prometheus with `openwebui_users_active` — headline DPM now 3.0 (was 1.0)
- [x] Verified per-series breakdown shows all 8 series with correct labels
- [x] Verified CSV and prom output formats unchanged
- [x] Run full script against production Prometheus instance to validate across all metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)