### PR TITLE
feat(cost) Make cost-aware DPM analysis the default interpretation path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,13 @@ Extract `cluster_slug` for the endpoint URL and `id` for the username.
 
 ### One-Shot Analysis (primary use case)
 
+Procure the contracted $/1000 active series from https://admin.grafana.com/, then:
+
 ```bash
-./dpm-finder.py -f json -m 2.0 -t 8 --timeout 120 -l 10
+./dpm-finder.py -f json -m 2.0 -t 8 --timeout 120 -l 10 --cost-per-1000-series 6.50
 ```
+
+Replace `6.50` with the customer's rate. Without the flag, results sort by DPM only.
 
 ### CLI Flags Reference
 
@@ -71,7 +75,7 @@ Extract `cluster_slug` for the endpoint URL and `id` for the username.
 | `-t`, `--threads` | `10` | Concurrent processing threads |
 | `-l`, `--lookback` | `10` | Lookback window in minutes for DPM calculation |
 | `--timeout` | `60` | API request timeout in seconds |
-| `--cost-per-1000-series` | _(none)_ | Dollar cost per 1000 series; adds estimated_cost column |
+| `--cost-per-1000-series` | _(none)_ | $/1000 active series; adds `estimated_cost` = `(series/1000)*rate*dpm` and sorts by highest cost. Get rate from admin.grafana.com |
 | `-q`, `--quiet` | `false` | Suppress progress output |
 | `-v`, `--verbose` | `false` | Enable debug logging |
 | `-e`, `--exporter` | `false` | Run as Prometheus exporter instead of one-shot |
@@ -83,10 +87,12 @@ Extract `cluster_slug` for the endpoint URL and `id` for the username.
 Output files are written to the current working directory.
 
 ### JSON (`-f json`) -> `metric_rates.json`
-Best for programmatic analysis. Includes per-series DPM breakdown:
+Best for programmatic analysis. Includes per-series DPM breakdown and a top-level `interpretation` object:
+- `interpretation` -- field meanings, sort order, prioritization, cost-rate source, link to README Interpreting Results
 - `metrics[].metric_name` -- the metric name
 - `metrics[].dpm` -- data points per minute (maximum across this metric's individual series)
 - `metrics[].series_count` -- number of active time series
+- `metrics[].estimated_cost` -- relative cost when `--cost-per-1000-series` is set; otherwise null
 - `metrics[].series_detail[]` -- per-label-set DPM breakdown (sorted by DPM descending)
 - `total_metrics_above_threshold` -- count of metrics above threshold
 - `performance_metrics.total_runtime_seconds` -- total processing time
@@ -95,22 +101,31 @@ Best for programmatic analysis. Includes per-series DPM breakdown:
 - `performance_metrics.metrics_per_second` -- processing throughput
 
 ### CSV (`-f csv`) -> `metric_rates.csv`
-Columns: `metric_name`, `dpm`, `series_count` (plus `estimated_cost` if `--cost-per-1000-series` is set).
+Columns: `metric_name`, `dpm`, `series_count` (plus `estimated_cost` if `--cost-per-1000-series` is set). File starts with `#` comment lines describing how to interpret results (stdout prints data rows only).
 
 ### Text (`-f text`) -> `metric_rates.txt`
-Human-readable format with per-series breakdown and performance statistics.
+Human-readable format with interpretation preamble, per-series breakdown, and performance statistics.
 
 ### Prometheus (`-f prom`) -> `metric_rates.prom`
-Prometheus exposition format suitable for Alloy's `prometheus.exporter.unix` textfile collector.
+Prometheus exposition format suitable for Alloy's `prometheus.exporter.unix` textfile collector. Includes `#` interpretation comments (scrapers ignore them). Does not emit `estimated_cost` as a metric.
 
 ## Interpreting Results
 
+DPM alone is a weak signal. Use **DPM together with `series_count`** to decide whether a metric is worth remediating.
+
 - **DPM** = data points per minute (maximum across this metric's individual series)
-- **series_count** = number of active time series for that metric
+- **series_count** = number of active time series (cardinality) for that metric
+- **estimated_cost** = `(series_count / 1000) * cost_per_1000_series * dpm` when `--cost-per-1000-series` is set
 - **series_detail** (JSON/text only) = per-label-combination DPM breakdown
-- Sort by DPM descending to find the noisiest metrics
-- For top metrics, examine `series_detail` to identify which label combinations drive the highest DPM
-- If `--cost-per-1000-series` is set, use `estimated_cost` to prioritize by spend
+
+### Cost-aware analysis (recommended)
+
+1. Pass `--cost-per-1000-series` with the customer's contracted rate from https://admin.grafana.com/ (list price is only a fallback).
+2. Output includes `estimated_cost` and is **sorted by highest cost first**.
+3. Focus remediation on the highest `estimated_cost` metrics (roughly the top ~10% by spend). Deprioritize the long-tail (~bottom 90% by cost) unless a metric is an obvious outlier.
+4. For top metrics, examine `series_detail` to identify which label combinations drive the highest DPM.
+
+When cost is not provided, results are sorted by DPM descending. CSV, JSON, text, and prom embed interpretation notes linking to README.md#interpreting-results.
 
 ## Rate Limiting
 

--- a/README.md
+++ b/README.md
@@ -52,15 +52,46 @@ python3 -m pip install -r requirements.txt
 
 ### 3. Run the script
 
-**One-time execution (traditional mode):**
-``` bash
-./dpm-finder.py -t 4 -f csv 
+**One-time execution (recommended: cost-aware):**
+
+Procure the contracted dollar cost per 1000 active series from [admin.grafana.com](https://admin.grafana.com/), then:
+
+```bash
+./dpm-finder.py -f json -m 2.0 -t 8 --timeout 120 -l 10 --cost-per-1000-series 6.50
 ```
 
+Replace `6.50` with the customer's rate. Without `--cost-per-1000-series`, results sort by DPM only.
+
 **Prometheus exporter mode:**
-``` bash
+```bash
 ./dpm-finder.py -e -p 9966
 ```
+
+## Interpreting Results
+
+DPM alone is a weak signal. Use **DPM together with `series_count` (cardinality)** to decide whether a metric is worth remediating. High DPM with few series may be noise; moderate DPM with many series often drives spend.
+
+### Fields
+
+| Field | Meaning |
+|-------|---------|
+| `dpm` | Data points per minute (maximum across this metric's individual series) |
+| `series_count` | Number of active time series (cardinality) for that metric |
+| `estimated_cost` | Relative cost estimate: `(series_count / 1000) * cost_per_1000_series * dpm` (only when `--cost-per-1000-series` is set) |
+| `series_detail` | Per-label-combination DPM breakdown (JSON/text only) |
+
+### Cost-aware analysis (recommended)
+
+1. Pass `--cost-per-1000-series` with the customer's contracted rate from [admin.grafana.com](https://admin.grafana.com/) (public list price is only a fallback estimate).
+2. Output includes `estimated_cost` and is **sorted by highest cost first**.
+3. Focus remediation on the **highest `estimated_cost` metrics** (roughly the top ~10% by spend). Deprioritize the long-tail (~bottom 90% by cost) unless a metric is an obvious outlier.
+4. For top metrics, examine `series_detail` to see which label combinations drive the highest DPM.
+
+When cost is not provided, results are sorted by DPM descending (noisiest first).
+
+### Self-describing output
+
+All one-shot output files (CSV, JSON, text, and prom) embed interpretation notes (field meanings, sort order, prioritization, cost-rate source) and link back to this section so shared artifacts remain understandable on their own. Prometheus exposition uses `#` comment lines (ignored by scrapers); estimated_cost is not emitted as a prom metric — use csv/json/text with `--cost-per-1000-series` for cost ranking.
 
 ## Docker Usage
 
@@ -411,8 +442,8 @@ optional arguments:
                          How often to update metrics in exporter mode, in seconds (default: 1 day or 86400 seconds)
   --timeout TIMEOUT     Request timeout in seconds for Prometheus API calls (default: 60)
   --cost-per-1000-series COST
-                        Dollar cost per 1000 active series. If provided, output includes estimated_cost
-                        and is sorted by highest cost.
+                        Dollar cost per 1000 active series (from admin.grafana.com).
+                        Adds estimated_cost=(series/1000)*rate*dpm and sorts by highest cost.
 
 ## Filtered Metrics
 
@@ -436,14 +467,17 @@ The script requires these Python packages (installed via requirements.txt):
 
 ### One-time Analysis
 ```bash
-# Basic CSV output
+# Cost-aware JSON (recommended) — use rate from admin.grafana.com
+./dpm-finder.py -f json -m 2.0 -t 8 --timeout 120 -l 10 --cost-per-1000-series 6.50
+
+# Basic CSV output (sorts by DPM only without cost flag)
 ./dpm-finder.py
 
 # JSON output with high threshold and more threads
 ./dpm-finder.py -f json -m 10.0 -t 16
 
 # Quiet mode for scripting
-./dpm-finder.py -q -f csv -m 2.0
+./dpm-finder.py -q -f csv -m 2.0 --cost-per-1000-series 6.50
 
 # Verbose debugging
 ./dpm-finder.py -v -t 8

--- a/dpm-finder.py
+++ b/dpm-finder.py
@@ -267,6 +267,84 @@ def process_metric_chunk(chunk, metric_value_url, username, api_key, results_que
     
     results_queue.put((chunk_results, chunk_times))
 
+INTERPRETATION_DOCS_URL = "https://github.com/grafana-ps/dpm-finder/blob/main/README.md#interpreting-results"
+
+
+def build_interpretation(cost_per_1000_series=None):
+    """Build self-describing interpretation metadata for JSON (and shared field copy)."""
+    cost_enabled = cost_per_1000_series is not None
+    estimated_cost_desc = (
+        "Approximate relative cost: (series_count/1000) * cost_per_1000_series * dpm."
+        if cost_enabled
+        else "Null — pass --cost-per-1000-series to compute estimated_cost = (series_count/1000) * rate * dpm."
+    )
+    return {
+        "summary": (
+            "Use dpm with series_count together; with cost enabled, prioritize by estimated_cost."
+            if cost_enabled
+            else "Use dpm with series_count together. Pass --cost-per-1000-series to rank by estimated spend."
+        ),
+        "fields": {
+            "dpm": "Data points per minute (max across this metric's series). Weak signal alone.",
+            "series_count": "Active time series (cardinality) for this metric.",
+            "estimated_cost": estimated_cost_desc,
+        },
+        "sort_order": (
+            "estimated_cost descending"
+            if cost_enabled
+            else "dpm descending (pass --cost-per-1000-series to sort by estimated_cost)"
+        ),
+        "prioritization": (
+            "Focus remediation on the highest estimated_cost metrics (roughly the top ~10% by spend). "
+            "Deprioritize the long-tail unless a metric is an obvious outlier."
+            if cost_enabled
+            else "Prefer metrics that combine high dpm with high series_count. "
+            "Pass --cost-per-1000-series to prioritize by estimated spend."
+        ),
+        "cost_rate_source": (
+            "Pass contracted $/1000 active series via --cost-per-1000-series "
+            "(from https://admin.grafana.com/)."
+        ),
+        "documentation": INTERPRETATION_DOCS_URL,
+    }
+
+
+def interpretation_preamble_lines(cost_per_1000_series=None):
+    """Shared interpretation lines (without comment prefix) for all file formats."""
+    lines = [
+        "dpm-finder results — how to interpret",
+        "dpm: data points per minute (weak alone); use with series_count",
+        "series_count: active series (cardinality)",
+    ]
+    if cost_per_1000_series is not None:
+        lines.extend([
+            "estimated_cost: (series_count/1000)*cost_per_1000_series*dpm; sorted highest first",
+            "Prioritize highest estimated_cost; deprioritize the long-tail (~bottom 90% by cost)",
+            "Cost rate: --cost-per-1000-series from https://admin.grafana.com/",
+        ])
+    else:
+        lines.append(
+            "Pass --cost-per-1000-series (from https://admin.grafana.com/) to add estimated_cost and sort by cost"
+        )
+    lines.append(f"Docs: {INTERPRETATION_DOCS_URL}")
+    return lines
+
+
+def comment_interpretation_preamble(cost_per_1000_series=None):
+    """'#' comment preamble for CSV and Prometheus exposition files."""
+    return "".join(f"# {line}\n" for line in interpretation_preamble_lines(cost_per_1000_series))
+
+
+def text_interpretation_preamble(cost_per_1000_series=None):
+    """Plain-text preamble for metric_rates.txt."""
+    lines = interpretation_preamble_lines(cost_per_1000_series)
+    return "\n".join(lines) + "\n\n"
+
+
+# Back-compat alias used by older call sites / tests
+csv_interpretation_preamble = comment_interpretation_preamble
+
+
 def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_aggregations, output_format='csv', min_dpm=1, quiet=False, thread_count=10, exporter_mode=False, timeout=60, cost_per_1000_series=None, lookback=10):
     """ 
     Calculate the metric rates
@@ -431,6 +509,7 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
     
     if output_format == 'csv':
         with open("metric_rates.csv", "w", encoding="utf-8") as f:
+            f.write(comment_interpretation_preamble(cost_per_1000_series))
             # Write CSV header
             if cost_per_1000_series is not None:
                 f.write("metric_name,dpm,series_count,estimated_cost\n")
@@ -453,6 +532,7 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
     elif output_format == 'json':
         import json
         output_data = {
+            "interpretation": build_interpretation(cost_per_1000_series),
             "metrics": enriched,
             "total_metrics_above_threshold": metrics_above_threshold,
             "performance_metrics": {
@@ -469,6 +549,12 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
     elif output_format == 'prom':
         output_filename = "metric_rates.prom"
         with open(output_filename, "w", encoding="utf-8") as f:
+            # Human guidance (scrapers ignore unknown '#' comment lines)
+            f.write(comment_interpretation_preamble(cost_per_1000_series))
+            f.write(
+                "# Note: estimated_cost is not emitted as a Prometheus metric; "
+                "use csv/json/text with --cost-per-1000-series for cost ranking.\n\n"
+            )
             # Add HELP and TYPE metadata for DPM metrics
             f.write("# HELP metric_dpm_rate Data points per minute for each metric\n")
             f.write("# TYPE metric_dpm_rate gauge\n")
@@ -513,8 +599,11 @@ def get_metric_rates(metric_value_url, username, api_key, metric_names, metric_a
     else:  # text/txt format
         output_filename = "metric_rates.txt"
         with open(output_filename, "w", encoding="utf-8") as f:
+            preamble = text_interpretation_preamble(cost_per_1000_series)
+            f.write(preamble)
             if not quiet:
-                print("\nMetrics: DPM and cardinality (series count):")
+                print("\n" + preamble, end='')
+                print("Metrics: DPM and cardinality (series count):")
             f.write("Metrics: DPM and cardinality (series count):\n")
             for item in enriched:
                 metric_name = item['metric_name']
@@ -782,7 +871,8 @@ def main():
         '--cost-per-1000-series',
         type=float,
         default=None,
-        help='Optional: Dollar cost per 1000 active series. If provided, output includes estimated_cost and is sorted by highest cost.'
+        help='Dollar cost per 1000 active series (from admin.grafana.com). '
+             'Adds estimated_cost=(series/1000)*rate*dpm and sorts by highest cost.'
     )
     args = parser.parse_args()
 

--- a/grafana-dpm-finder/agents/grafana-dpm-finder.md
+++ b/grafana-dpm-finder/agents/grafana-dpm-finder.md
@@ -68,13 +68,17 @@ If venv exists, activate it:
 source {repo_root}/venv/bin/activate
 ```
 
-## Step 4: Run DPM Analysis
+## Step 4: Obtain Cost Rate and Run Analysis
 
-Execute the tool with JSON output for structured parsing:
+Before running, ask the user for the contracted **dollar cost per 1000 active series** from [admin.grafana.com](https://admin.grafana.com/). Public list price is only a fallback estimate if they cannot look it up.
+
+Execute the tool with JSON output and cost estimation:
 
 ```bash
-cd {repo_root} && source venv/bin/activate && python3 dpm-finder.py -f json -m 2.0 -t 8 --timeout 120 -l 10
+cd {repo_root} && source venv/bin/activate && python3 dpm-finder.py -f json -m 2.0 -t 8 --timeout 120 -l 10 --cost-per-1000-series <RATE>
 ```
+
+Replace `<RATE>` with the value the user provided. If they decline to supply a rate, run without the flag and note that results will sort by DPM only.
 
 If the user provided custom flags or thresholds, adjust accordingly. See CLAUDE.md for the full CLI flags reference.
 
@@ -85,19 +89,21 @@ Monitor the output for errors:
 
 ## Step 5: Present Results
 
-Read and parse `{repo_root}/metric_rates.json`:
+Read and parse `{repo_root}/metric_rates.json`. Prefer the top-level `interpretation` object when summarizing how to read the results for the user.
 
-1. Present a summary table sorted by DPM descending:
+1. Present a summary table. When `estimated_cost` is present, the file is already sorted by cost descending — keep that order. Otherwise sort/present by DPM descending:
 
 | Metric | DPM | Active Series | Est. Cost |
 |--------|-----|---------------|-----------|
 | metric_name | value | count | cost_if_available |
 
-2. For the **top 5 metrics** by DPM, show the per-series breakdown:
+2. Recommend action on the **costliest metrics** (roughly top ~10% by `estimated_cost`). Deprioritize the long-tail (~bottom 90% by cost) unless a metric is an obvious outlier. When cost is unavailable, use high DPM + high `series_count` together.
+
+3. For the **top 5 metrics** by `estimated_cost` (fallback: DPM), show the per-series breakdown:
    - List the label combinations driving the highest DPM
    - Use `series_detail` from the JSON output
 
-3. Include totals:
+4. Include totals:
    - Total metrics above threshold
    - Processing time from performance stats
 

--- a/grafana-dpm-finder/skills/analyze/SKILL.md
+++ b/grafana-dpm-finder/skills/analyze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze
-description: Analyze Prometheus metric DPM rates for a Grafana Cloud stack. Identifies which metrics drive high data points per minute with per-label breakdown. Optionally uses gcx for stack discovery. Usage: /grafana-dpm-finder:analyze [stack-name-or-options]
+description: Analyze Prometheus metric DPM rates for a Grafana Cloud stack. Identifies which metrics drive high data points per minute with per-label breakdown and optional cost ranking. Optionally uses gcx for stack discovery. Usage: /grafana-dpm-finder:analyze [stack-name-or-options]
 context: fork
 agent: grafana-dpm-finder
 disable-model-invocation: false
@@ -12,6 +12,7 @@ Instructions:
 1. If $ARGUMENTS contains a stack name, use it for gcx lookup or .env configuration.
 2. If $ARGUMENTS is empty, check for gcx availability and present the active stack context for confirmation.
 3. If no gcx and no arguments, check if a .env file exists in the dpm-finder repo with valid credentials.
-4. Follow the complete workflow: discover stack -> setup environment -> run analysis -> present results.
-5. Always confirm the target stack with the user before running the analysis.
-6. Present results as a formatted table sorted by DPM descending.
+4. Ask for the contracted $/1000 active series from https://admin.grafana.com/ before running (required for cost-aware ranking).
+5. Follow the complete workflow: discover stack -> setup environment -> obtain cost rate -> run analysis with --cost-per-1000-series -> present results.
+6. Always confirm the target stack with the user before running the analysis.
+7. Present results as a formatted table sorted by estimated_cost descending when available; otherwise by DPM descending. Prefer reading the JSON `interpretation` object. Focus remediation on the costliest metrics (~top 10% by spend).


### PR DESCRIPTION
* Documents cost-aware DPM analysis as the primary workflow: use DPM + `series_count` together, pass `--cost-per-1000-series` (rate from [admin.grafana.com](https://admin.grafana.com/)), and prioritize the highest `estimated_cost` metrics (~top 10% by spend) rather than optimizing the long-tail. This is the practical solution.
* Makes all one-shot outputs self-describing — CSV (# preamble), JSON (interpretation object), text (plain preamble), and prom (# comments ignored by scrapers) — with field meanings, sort order, prioritization, and a link to `README.md#interpreting-results`.
* Aligns the grafana-dpm-finder agent/skill and CLI help so cost-first runs (ask for $/1k series, sort/present by estimated_cost) are the default path.

## Suggested test plan

- [ ] Run with cost: ./dpm-finder.py -f json -m 2.0 -t 8 --timeout 120 -l 10 --cost-per-1000-series 6.50 and confirm metric_rates.json has interpretation, metrics sorted by estimated_cost, and estimated_cost populated
- [ ] Run -f csv with cost and confirm # interpretation preamble precedes the header; stdout remains data rows only
- [ ] Run -f text and -f prom with cost and confirm the same guidance appears (prom: comment-only; no estimated_cost gauge)
- [ ] Run without --cost-per-1000-series and confirm interpretation text adapts (sort by DPM; guidance to pass the flag)
- [ ] Confirm README #interpreting-results anchor and CLAUDE/AGENTS guidance match the embedded docs URL
- [ ] Spot-check agent/skill: asks for rate from admin.grafana.com and presents top metrics by cost